### PR TITLE
Clean up mentors page to make it easier to browse mentors

### DIFF
--- a/_includes/mentors.html
+++ b/_includes/mentors.html
@@ -1,41 +1,36 @@
-<h2>Mentors</h2>
-
-{% for person in site.data.mentors %}
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    {% if person.link %}
-    <a style="text-align: top;color:#fff" href="{{person.link}}">
+<div class="mentorGridContainer">
+    {% for person in site.data.mentors %}
+    <div class="mentor">
+        <!-- Name -->
+        {% if person.link %}
+        <a style="text-align: top;color:#fff" href="{{person.link}}">
+            <span class="person-name">{{person.name}}</span>
+        </a>
+        {% else %}
         <span class="person-name">{{person.name}}</span>
-    </a>
-    {% else %}
-    <span class="person-name">{{person.name}}</span>
-    {% endif %}
-    <br>
-    <span class="person-major">{{person.major}}</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;{{person.huskyemail}} <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;{{person.year}}
-    <br><br>
+        {% endif %}
+        <br>
+        <span class="person-major">{{person.major}}</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;{{person.huskyemail}} <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;{{person.year}}
+        <br><br>
 
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    {% for skill in person.skills %}
-    - {{skill}}<br>
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        {% for skill in person.skills %}
+        - {{skill}}<br>
+        {% endfor %}
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        {% for coop in person.coops %}
+        - {{coop}}<br>
+        {% endfor %}
+    </div>
     {% endfor %}
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    {% for coop in person.coops %}
-    - {{coop}}<br>
-    {% endfor %}
-
-
 </div>
-<br><br><br>
-{% endfor %}
 
 <br><br><br>
 <em>...complete <a href="https://forms.gle/fw7E7p4NS6vszeuQ6">this form</a> to be added as a mentor!</em>

--- a/_site/assets/main.css
+++ b/_site/assets/main.css
@@ -103,19 +103,31 @@ footer {
   line-height: 0.6em;
   padding: 0 5px; }
 
+.mentorGridContainer {
+  display: grid;
+  grid-template-columns: auto;
+  grid-template-rows: auto;
+  grid-gap: 40px;
+  padding: 0 20px; }
+
 /*** media queries ***/
 /* X-Small devices (phones, 480px and up) */
 @media (min-width: 480px) {
   /* wrapper stays 480px wide past 480px wide and is kept centered */
   .wrapper {
     width: 480px;
-    margin: 10% auto 0 auto; } }
+    margin: 10% auto 0 auto; }
+
+  /* Use two columns in grid if screen is at least 480px wide*/
+  .mentorGridContainer {
+    grid-template-columns: auto auto; } }
 /* All other devices (768px and up) */
 @media (min-width: 768px) {
   /* past 768px the layout is changed and the wrapper has a fixed width of 680px
   to accomodate both the header column and the content column */
   .wrapper {
-    width: 680px; }
+    width: 680px;
+    height: 500px; }
 
   /* the header column stays left and has a dynamic width with all contents
   aligned right */
@@ -132,4 +144,7 @@ footer {
   main {
     width: 60%;
     margin-left: 54%;
-    padding: 0; } }
+    height: 100%; }
+
+  #mentors-title {
+    font-size: 50px; } }

--- a/_site/mentors/index.html
+++ b/_site/mentors/index.html
@@ -114,6 +114,7 @@
     </div>
     
   </header>
+
   <main>
     
     <div class="content">
@@ -135,804 +136,807 @@
     </a>
     &nbsp;&nbsp;&nbsp;
 </div>
-      <h2>Mentors</h2>
+      <h2 id="mentors-title">Fall 2019 Mentors</h2>
+    </div>
+    
+  </main>
 
+  <div class="centered-content">
+    <div class="mentorGridContainer">
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <a style="text-align: top;color:#fff" href="https://joshspicer.com">
+            <span class="person-name">Josh Spicer</span>
+        </a>
+        
+        <br>
+        <span class="person-major">computer science</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;spicer.jo <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
 
-<div class="eboardMember">
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - react native<br>
+        
+        - cyber security<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - VSR<br>
+        
+        - Akamai<br>
+        
+        - Microsoft<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <a style="text-align: top;color:#fff" href="http://anujmodi.com">
+            <span class="person-name">Anuj Modi</span>
+        </a>
+        
+        <br>
+        <span class="person-major">computer science + cyber ops (minor in math)</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;modi.an <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
 
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - cyber<br>
+        
+        - sysadmin<br>
+        
+        - AWS<br>
+        
+        - virtualization<br>
+        
+        - networking<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - MITRE<br>
+        
+        - ASICS Digital<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Katie Busemeyer</span>
+        
+        <br>
+        <span class="person-major">computer science + cognitive psychology</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;busemeyer.k <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
 
-    <!-- Name -->
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - react<br>
+        
+        - JS<br>
+        
+        - HTML<br>
+        
+        - CSS<br>
+        
+        - Ruby on Rails<br>
+        
+        - Tableau<br>
+        
+        - SQL<br>
+        
+        - Java<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Rue La La<br>
+        
+        - ezCater<br>
+        
+        - Bank of America (internship)<br>
+        
+    </div>
     
-    <a style="text-align: top;color:#fff" href="https://joshspicer.com">
-        <span class="person-name">Josh spicer</span>
-    </a>
-    
-    <br>
-    <span class="person-major">computer science</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;spicer.jo <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
-    <br><br>
+    <div class="mentor">
+        <!-- Name -->
+        
+        <a style="text-align: top;color:#fff" href="http://jennder.github.io">
+            <span class="person-name">Jenn Der</span>
+        </a>
+        
+        <br>
+        <span class="person-major">computer science + media arts</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;der.je <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
 
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - python<br>
+        
+        - aws<br>
+        
+        - elastic<br>
+        
+        - api dev<br>
+        
+        - ruby<br>
+        
+        - sql<br>
+        
+        - racket<br>
+        
+        - javascript/typescript (angular)<br>
+        
+        - java<br>
+        
+        - adobe (photoshop, illustrator, bridge, lightroom, premiere)<br>
+        
+        - cpp (graphics)<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Kyruus<br>
+        
+        - Massachusetts Medical Society<br>
+        
+    </div>
     
-    - react native<br>
-    
-    - cyber security<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - VSR<br>
-    
-    - Akamai<br>
-    
-    - Microsoft<br>
-    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <a style="text-align: top;color:#fff" href="http://ccgomes.com">
+            <span class="person-name">Chris Gomes</span>
+        </a>
+        
+        <br>
+        <span class="person-major">computer science + business administration</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;gomes.chri <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
 
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - python<br>
+        
+        - scala<br>
+        
+        - java<br>
+        
+        - data science<br>
+        
+        - machine learning<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Suffolk Construction<br>
+        
+        - Spotify<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Ray Huang</span>
+        
+        <br>
+        <span class="person-major">computer science + media arts</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;huang.ra <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
 
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - virtual reality/augmented reality (VR/AR)<br>
+        
+        - game dev<br>
+        
+        - front-end<br>
+        
+        - web dev<br>
+        
+        - react<br>
+        
+        - graphics<br>
+        
+        - 3d modeling/art<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Facebook<br>
+        
+        - Pison<br>
+        
+        - Intuit<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Isabel Bolger</span>
+        
+        <br>
+        <span class="person-major">computer science</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;bolger.i <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;3rd year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - git<br>
+        
+        - HTML<br>
+        
+        - CSS<br>
+        
+        - Java<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Microsoft (internship)<br>
+        
+        - co op at a gaming company in sf<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Jalaj Singh</span>
+        
+        <br>
+        <span class="person-major">computer science</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;singh.ja <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;2nd year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - java<br>
+        
+        - neo4j<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - small data management company (internship)<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <a style="text-align: top;color:#fff" href="http://jakobeha.github.io">
+            <span class="person-name">Jakob Hain</span>
+        </a>
+        
+        <br>
+        <span class="person-major">computer science</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;Hain.j <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;3rd year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - PL<br>
+        
+        - functional programming<br>
+        
+        - git<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Research co-op at PRL<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <a style="text-align: top;color:#fff" href="github.com/jaronoff97jaronoff.com">
+            <span class="person-name">Jacob Aronoff</span>
+        </a>
+        
+        <br>
+        <span class="person-major">computer science</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;aronoff.j <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - cloud<br>
+        
+        - backend<br>
+        
+        - app dev<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Datadog<br>
+        
+        - Drift<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Fiona McCrae</span>
+        
+        <br>
+        <span class="person-major">Cybersecurity BSPolitical Science Minor</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;mccrae.f <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;2nd year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - cyber security<br>
+        
+        - linux<br>
+        
+        - writing/editing<br>
+        
+        - java<br>
+        
+        - maven<br>
+        
+        - confluence<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Eli Kirmayer</span>
+        
+        <br>
+        <span class="person-major">cs</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;kirmayer.e <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - python<br>
+        
+        - databases<br>
+        
+        - lil bit of R<br>
+        
+        - some web frameworks<br>
+        
+        - algorithms<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Nvidia<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <a style="text-align: top;color:#fff" href="https://github.com/dtxcode">
+            <span class="person-name">David Tandetnik</span>
+        </a>
+        
+        <br>
+        <span class="person-major">Computer Science</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;tandetnik.da <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - back-end cloud development (AWS, GCP)<br>
+        
+        - server architecture<br>
+        
+        - server design (microservices, kubernetes)<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Skillz<br>
+        
+        - Mercari<br>
+        
+        - Amazon<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Zheng Fang</span>
+        
+        <br>
+        <span class="person-major">Computer Information</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;zackandaerith1@gmail.com <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;Master's
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - Git<br>
+        
+        - R<br>
+        
+        - python<br>
+        
+        - SAS<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <a style="text-align: top;color:#fff" href="https://github.com/shanetimmerman">
+            <span class="person-name">Shane Timmerman</span>
+        </a>
+        
+        <br>
+        <span class="person-major">computer science + biology</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;shanetimmerman@gmail.com <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - python<br>
+        
+        - java<br>
+        
+        - JS<br>
+        
+        - scala<br>
+        
+        - elixir<br>
+        
+        - perl frameworks<br>
+        
+        - flask<br>
+        
+        - react<br>
+        
+        - phoenix<br>
+        
+        - kivy<br>
+        
+        - MS SQL<br>
+        
+        - mySql<br>
+        
+        - postgreSQL<br>
+        
+        - SQLite<br>
+        
+        - hive<br>
+        
+        - hadoop<br>
+        
+        - spark<br>
+        
+        - git<br>
+        
+        - docker<br>
+        
+        - pytest<br>
+        
+        - kafka<br>
+        
+        - kubernetes<br>
+        
+        - helm<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Wayfair<br>
+        
+        - FluidScreen<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Victoria Yang</span>
+        
+        <br>
+        <span class="person-major">computer science + business</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;yang.wenhu <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;5th year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - java<br>
+        
+        - python<br>
+        
+        - ruby on rails<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Workday<br>
+        
+        - Morgan Stanley (internship)<br>
+        
+        - Coinbase<br>
+        
+        - startup (product management internship)<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Mohini Limbodia</span>
+        
+        <br>
+        <span class="person-major">computer science</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;limbodia.m <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;Master's
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - currently doing a co-op<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Nate Hofmann</span>
+        
+        <br>
+        <span class="person-major">computer science (minor in Economics)</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;hofmann.n <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;3rd year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - python<br>
+        
+        - java<br>
+        
+        - SQL<br>
+        
+        - git<br>
+        
+        - bash<br>
+        
+        - javaFX<br>
+        
+        - python imaging library<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Draper Laboratory<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <a style="text-align: top;color:#fff" href="https://github.com/makenaoda">
+            <span class="person-name">Makena Oda</span>
+        </a>
+        
+        <br>
+        <span class="person-major">computer science and criminal justice</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;oda.m <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;2nd year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - java<br>
+        
+        - racket<br>
+        
+        - adobe premiere<br>
+        
+        - adobe photoshop and illustrator<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <span class="person-name">Nickhil Tekwani</span>
+        
+        <br>
+        <span class="person-major">computer science + communication studies</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;tekwani.n <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;2nd year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - JS<br>
+        
+        - react<br>
+        
+        - git<br>
+        
+        - SQL<br>
+        
+        - tableau<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Cloudera<br>
+        
+        - Optum (internship)<br>
+        
+    </div>
+    
+    <div class="mentor">
+        <!-- Name -->
+        
+        <a style="text-align: top;color:#fff" href="http://feliciazhang.github.io">
+            <span class="person-name">Felicia Zhang</span>
+        </a>
+        
+        <br>
+        <span class="person-major">computer engineering + computer science</span>
+        <br><br>
+        <!-- Stats -->
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;zhang.fel <br>
+        <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
+        <br><br>
+
+        <!-- Skills -->
+        <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
+        
+        - web dev - react/redux - vue - JS - TS<br>
+        
+        - electronics<br>
+        
+        <br>
+        <!-- Co-ops -->
+        <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
+        
+        - Drift<br>
+        
+        - Google<br>
+        
+        - Carbonite<br>
+        
+    </div>
+    
 </div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <a style="text-align: top;color:#fff" href="http://anujmodi.com">
-        <span class="person-name">Anuj Modi</span>
-    </a>
-    
-    <br>
-    <span class="person-major">computer science + cyber ops (minor in math)</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;modi.an <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - cyber<br>
-    
-    - sysadmin<br>
-    
-    - AWS<br>
-    
-    - virtualization<br>
-    
-    - networking<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - MITRE<br>
-    
-    - ASICS Digital<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <span class="person-name">Katie Busemeyer</span>
-    
-    <br>
-    <span class="person-major">computer science + cognitive psychology</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;busemeyer.k <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - react<br>
-    
-    - JS<br>
-    
-    - HTML<br>
-    
-    - CSS<br>
-    
-    - Ruby on Rails<br>
-    
-    - Tableau<br>
-    
-    - SQL<br>
-    
-    - Java<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Rue La La<br>
-    
-    - ezCater<br>
-    
-    - Bank of America (internship)<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <a style="text-align: top;color:#fff" href="http://ccgomes.com">
-        <span class="person-name">Chris Gomes</span>
-    </a>
-    
-    <br>
-    <span class="person-major">computer science + business administration</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;gomes.chri <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - python<br>
-    
-    - scala<br>
-    
-    - java<br>
-    
-    - data science<br>
-    
-    - machine learning<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Suffolk Construction<br>
-    
-    - Spotify<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <span class="person-name">Isabel Bolger</span>
-    
-    <br>
-    <span class="person-major">computer science</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;bolger.i <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;3rd year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - git<br>
-    
-    - HTML<br>
-    
-    - CSS<br>
-    
-    - Java<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Microsoft (internship)<br>
-    
-    - co op at a gaming company in sf<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <span class="person-name">Jalaj Singh</span>
-    
-    <br>
-    <span class="person-major">computer science</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;singh.ja <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;2nd year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - java<br>
-    
-    - neo4j<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - small data management company (internship)<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <a style="text-align: top;color:#fff" href="http://jakobeha.github.io">
-        <span class="person-name">Jakob Hain</span>
-    </a>
-    
-    <br>
-    <span class="person-major">computer science</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;Hain.j <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;3rd year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - PL<br>
-    
-    - functional programming<br>
-    
-    - git<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Research co-op at PRL<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <a style="text-align: top;color:#fff" href="github.com/jaronoff97jaronoff.com">
-        <span class="person-name">Jacob Aronoff</span>
-    </a>
-    
-    <br>
-    <span class="person-major">computer science</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;aronoff.j <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - cloud<br>
-    
-    - backend<br>
-    
-    - app dev<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Datadog<br>
-    
-    - Drift<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <span class="person-name">Fiona McCrae</span>
-    
-    <br>
-    <span class="person-major">Cybersecurity BSPolitical Science Minor</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;mccrae.f <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;2nd year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - cyber security<br>
-    
-    - linux<br>
-    
-    - writing/editing<br>
-    
-    - java<br>
-    
-    - maven<br>
-    
-    - confluence<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <span class="person-name">Eli Kirmayer</span>
-    
-    <br>
-    <span class="person-major">cs</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;kirmayer.e <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - python<br>
-    
-    - databases<br>
-    
-    - lil bit of R<br>
-    
-    - some web frameworks<br>
-    
-    - algorithms<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Nvidia<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <a style="text-align: top;color:#fff" href="https://github.com/dtxcode">
-        <span class="person-name">David Tandetnik</span>
-    </a>
-    
-    <br>
-    <span class="person-major">Computer Science</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;tandetnik.da <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - back-end cloud development (AWS, GCP)<br>
-    
-    - server architecture<br>
-    
-    - server design (microservices, kubernetes)<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Skillz<br>
-    
-    - Mercari<br>
-    
-    - Amazon (internship)<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <span class="person-name">Zheng Fang</span>
-    
-    <br>
-    <span class="person-major">Computer Information</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;zackandaerith1@gmail.com <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;Master's
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - Git<br>
-    
-    - R<br>
-    
-    - python<br>
-    
-    - SAS<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <a style="text-align: top;color:#fff" href="https://github.com/shanetimmerman">
-        <span class="person-name">Shane Timmerman</span>
-    </a>
-    
-    <br>
-    <span class="person-major">computer science + biology</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;shanetimmerman@gmail.com <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - python<br>
-    
-    - java<br>
-    
-    - JS<br>
-    
-    - scala<br>
-    
-    - elixir<br>
-    
-    - perl frameworks<br>
-    
-    - flask<br>
-    
-    - react<br>
-    
-    - phoenix<br>
-    
-    - kivy<br>
-    
-    - MS SQL<br>
-    
-    - mySql<br>
-    
-    - postgreSQL<br>
-    
-    - SQLite<br>
-    
-    - hive<br>
-    
-    - hadoop<br>
-    
-    - spark<br>
-    
-    - git<br>
-    
-    - docker<br>
-    
-    - pytest<br>
-    
-    - kafka<br>
-    
-    - kubernetes<br>
-    
-    - helm<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Wayfair<br>
-    
-    - FluidScreen<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <span class="person-name">Victoria Yang</span>
-    
-    <br>
-    <span class="person-major">computer science + business</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;yang.wenhu <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;5th year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - java<br>
-    
-    - python<br>
-    
-    - ruby on rails<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Workday<br>
-    
-    - Morgan Stanley (internship)<br>
-    
-    - Coinbase<br>
-    
-    - startup (product management internship)<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <span class="person-name">Mohini Limbodia</span>
-    
-    <br>
-    <span class="person-major">computer science</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;limbodia.m <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;Master's
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - currently doing a co-op<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <span class="person-name">Nate Hofmann</span>
-    
-    <br>
-    <span class="person-major">computer science (minor in Economics)</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;hofmann.n <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;3rd year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - python<br>
-    
-    - java<br>
-    
-    - SQL<br>
-    
-    - git<br>
-    
-    - bash<br>
-    
-    - javaFX<br>
-    
-    - python imaging library<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Draper Laboratory<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <a style="text-align: top;color:#fff" href="https://github.com/makenaoda">
-        <span class="person-name">Makena Oda</span>
-    </a>
-    
-    <br>
-    <span class="person-major">computer science and criminal justice</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;oda.m <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;2nd year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - java<br>
-    
-    - racket<br>
-    
-    - adobe premiere<br>
-    
-    - adobe photoshop and illustrator<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <span class="person-name">Nickhil Tekwani</span>
-    
-    <br>
-    <span class="person-major">computer science + communication studies</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;tekwani.n <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;2nd year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - JS<br>
-    
-    - react<br>
-    
-    - git<br>
-    
-    - SQL<br>
-    
-    - tableau<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Cloudera<br>
-    
-    - Optum (internship)<br>
-    
-
-
-</div>
-<br><br><br>
-
-<div class="eboardMember">
-
-
-    <!-- Name -->
-    
-    <a style="text-align: top;color:#fff" href="http://feliciazhang.github.io">
-        <span class="person-name">Felicia Zhang</span>
-    </a>
-    
-    <br>
-    <span class="person-major">computer engineering + computer science</span>
-    <br><br>
-    <!-- Stats -->
-    <i class="fa fa-envelope-o" aria-hidden="true"></i>&nbsp;&nbsp;zhang.fel <br>
-    <i class="fa fa-clock-o" aria-hidden="true"></i>&nbsp;&nbsp;4th year
-    <br><br>
-
-    <!-- Skills -->
-    <i class="fa fa-lightbulb-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Skills</b><br>
-    
-    - web dev - react/redux - vue - JS - TS<br>
-    
-    - electronics<br>
-    
-    <br>
-    <!-- Co-ops -->
-    <i class="fa  fa-building-o" aria-hidden="true"></i>&nbsp;&nbsp;<b>Co-ops</b><br>
-    
-    - Drift<br>
-    
-    - Google<br>
-    
-    - Carbonite<br>
-    
-
-
-</div>
-<br><br><br>
-
 
 <br><br><br>
 <em>...complete <a href="https://forms.gle/fw7E7p4NS6vszeuQ6">this form</a> to be added as a mentor!</em>
 <br><br>
-      <hr />
+    <hr />
 
 <ul class="fa-ul main-list">
     <li class="main-list-item">
         <span class="fa fa-calendar fa-lg main-list-item-icon"></span>
-        <a href="https://parade.events/o/5b7d4d794daf7a8444303b35">Parade</a>
+        <a href="https://app.parade.events/orgs/5b7d4d794daf7a8444303b35">Parade</a>
     </li>
     <li class="main-list-item">
         <span class="fa fa-facebook fa-lg main-list-item-icon"></span>
@@ -948,13 +952,11 @@
     </li>
         <li class="main-list-item">
         <span class="fa fa-slack fa-lg main-list-item-icon"></span>
-        <a href="https://join.slack.com/t/nucosmo/shared_invite/enQtNzQ5MzM2MDgzODkzLTg4ODJjZGYyNmZlYjIwOTBjZWQxM2I4NDAzNGZkMGUyZGNjYzJmNTg0NjkwNjk4ZTg2ZTU2MTVjNmJmYTBmY2M">Join our Slack</a>
+        <a href="https://join.slack.com/t/nucosmo/signup">Join our Slack</a>
     </li>
     <br><br>
 
-    </div>
-    
-  </main>
+  </div>
 </div>
 
   </body>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -132,6 +132,15 @@ footer {
 	padding: 0 5px;
 }
 
+// Grid for mentors
+.mentorGridContainer {
+	display: grid;
+	grid-template-columns: auto;  
+	grid-template-rows: auto;
+	grid-gap: 40px;
+	padding: 0 20px;
+}
+
 /*** media queries ***/
 /* X-Small devices (phones, 480px and up) */
 @media (min-width: 480px) {
@@ -139,6 +148,11 @@ footer {
 	.wrapper {
 		width: 480px;
 		margin: 10% auto 0 auto;
+	}
+
+	/* Use two columns in grid if screen is at least 480px wide*/
+	.mentorGridContainer {
+		grid-template-columns: auto auto;  
 	}
 }
 
@@ -148,6 +162,7 @@ footer {
 	to accomodate both the header column and the content column */
 	.wrapper {
 		width: 680px;
+		height: 500px;
 	}
 
 	/* the header column stays left and has a dynamic width with all contents
@@ -167,6 +182,10 @@ footer {
 	main {
 		width: 60%;
 		margin-left: 54%;
-		padding: 0;
+		height: 100%;
+	}
+
+	#mentors-title {
+		font-size: 50px;
 	}
 }

--- a/mentors.html
+++ b/mentors.html
@@ -22,13 +22,18 @@ layout: base
     </div>
     {% endif %}
   </header>
+
   <main>
     {% if site.compass.include_content %}
     <div class="content">
       {% include nav.html%}
-      {% include mentors.html %}
-      {% include socials.html%}
+      <h2 id="mentors-title">Fall 2019 Mentors</h2>
     </div>
     {% endif %}
   </main>
+
+  <div class="centered-content">
+    {% include mentors.html %}
+    {% include socials.html%}
+  </div>
 </div>


### PR DESCRIPTION
Cleaned up mentors page by creating a grid that sits below the main CoSMO logo. Because the Jekyll theme assumed everything was to be split into two columns, I had to add another div outside of `<header>` and `<main>`

Let me know if any spacing looks weird or if you think 3 columns would be better.
Either way this should help us scale as we get more mentors.

Here are some screenshots for 3 different screen sizes:

![image](https://user-images.githubusercontent.com/11139006/71863372-a8b23600-30ca-11ea-9acb-e2f7554cfae0.png)

![image](https://user-images.githubusercontent.com/11139006/71863393-b7005200-30ca-11ea-9dde-d5e7b89422c9.png)

![image](https://user-images.githubusercontent.com/11139006/71863403-be276000-30ca-11ea-95c9-089978fc43f3.png)